### PR TITLE
fix(argocd): make sealed-secrets check more robust

### DIFF
--- a/template/bootstrap-cluster/argocd.yaml
+++ b/template/bootstrap-cluster/argocd.yaml
@@ -143,10 +143,14 @@ tasks:
       KUBECONFIG: "{{ '{{.ENV}}' }}/kubeconfig"
     cmds:
       - |
-        echo "Waiting for sealed-secrets-controller to be ready..."
+        echo "Waiting for sealed-secrets-controller pod to be created..."
+        until kubectl get pod -n kube-system -l app.kubernetes.io/name=sealed-secrets -o jsonpath='{.items[0].metadata.name}' >/dev/null 2>&1; do
+          sleep 5
+        done
+        echo "Pod created. Waiting for it to be ready..."
         kubectl wait --for=condition=ready pod -n kube-system -l app.kubernetes.io/name=sealed-secrets --timeout=120s
         echo "Waiting for sealed-secrets-controller service to be available..."
-        until kubectl get endpoints -n kube-system sealed-secrets-controller -o jsonpath='{.subsets[?(@.addresses)].addresses[0].ip}' 2>/dev/null; do
+        until kubectl get endpoints -n kube-system sealed-secrets-controller -o jsonpath='{.subsets[?(@.addresses)].addresses[0].ip}' >/dev/null 2>&1; do
           sleep 5
         done
         echo "sealed-secrets-controller is ready."


### PR DESCRIPTION
## Summary
This pull request makes the `monitor_sealed_secrets` task more robust by adding a multi-stage check that waits for the pod to exist, then for the pod to be ready, and finally for the service endpoint to be available. This prevents a race condition that was causing intermittent failures during the bootstrap process.

## Test plan
- [x] Run `task deploy-sandbox` multiple times to ensure the sealed-secrets check is reliable.

🤖 Generated with [opencode](https://opencode.ai)