### PR TITLE
fix: VCS ref for test template workflow on main

### DIFF
--- a/.github/workflows/test-template.yaml
+++ b/.github/workflows/test-template.yaml
@@ -45,12 +45,14 @@ jobs:
 
       - name: Test Template
         shell: bash
+        env:
+          VCS_REF: ${{ github.head_ref || github.ref_name || github.sha }}
         run: |
-          echo "Installing template from $GITHUB_HEAD_REF"
+          echo "Installing template from ${VCS_REF}"
           copier copy \
           --trust \
           --defaults \
-          --vcs-ref=$GITHUB_HEAD_REF \
+          --vcs-ref=${VCS_REF} \
           https://github.com/sixfeetup/scaf-fullstack-template.git test-project
 
       - name: Run lint and formatting checks


### PR DESCRIPTION
Replace GITHUB_HEAD_REF with `${{ github.head_ref || github.ref_name || github.sha }}` so the template test workflow runs on main, PRs, schedule, and manual dispatch.