### PR TITLE
fix: no space left on device in github actions runner

### DIFF
--- a/.github/workflows/test-template.yaml
+++ b/.github/workflows/test-template.yaml
@@ -15,6 +15,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Proposed as fix for "no space left on device":
+      # See https://github.com/actions/runner-images/issues/2875
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
Action output
```
AFTER CLEAN-UP:
$ dh -h /
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   27G   46G  37% /
$ dh -a /
Filesystem     1K-blocks     Used Available Use% Mounted on
/dev/root       75085112 27470644  47598084  37% /
$ dh -a
Filesystem     1K-blocks     Used Available Use% Mounted on
/dev/root       75085112 27470644  47598084  37% /
devtmpfs         8186144        0   8186144   0% /dev
proc                   0        0         0    - /proc
sysfs                  0        0         0    - /sys
securityfs             0        0         0    - /sys/kernel/security
tmpfs            8189736       84   8189652   1% /dev/shm
devpts                 0        0         0    - /dev/pts
tmpfs            3275896     1124   3274772   1% /run
tmpfs               5120        0      5120   0% /run/lock
cgroup2                0        0         0    - /sys/fs/cgroup
pstore                 0        0         0    - /sys/fs/pstore
bpf                    0        0         0    - /sys/fs/bpf
systemd-1              -        -         -    - /proc/sys/fs/binfmt_misc
hugetlbfs              0        0         0    - /dev/hugepages
mqueue                 0        0         0    - /dev/mqueue
debugfs                0        0         0    - /sys/kernel/debug
tracefs                0        0         0    - /sys/kernel/tracing
fusectl                0        0         0    - /sys/fs/fuse/connections
configfs               0        0         0    - /sys/kernel/config
/dev/sda16        901520    62796    775596   8% /boot
/dev/sda15        106832     6250    100582   6% /boot/efi
binfmt_misc            0        0         0    - /proc/sys/fs/binfmt_misc
/dev/sdb1       76829444       28  72880976   1% /mnt
tmpfs            1637944       12   1637932   1% /run/user/1001
================================================================================
/dev/root:
********************************************************************************
=> Saved 27GiB
********************************************************************************
overall:
********************************************************************************
=> Saved 31GiB
********************************************************************************
```