### PR TITLE
fix(nix): replace nodePackages.eslint/prettier with top-level equivalents

### DIFF
--- a/template/flake.nix
+++ b/template/flake.nix
@@ -48,8 +48,8 @@
             kubernetes-helm
             kubeseal
             nodejs_22
-            nodePackages.eslint
-            nodePackages.prettier
+            eslint
+            prettier
             openssh
             opentofu
             pass


### PR DESCRIPTION
https://github.com/getscaf/sfu-fullstack-template/issues/166

nodePackages was removed from nixpkgs due to maintainability concerns eslint and prettier are now available as top-level packages in nixpkgs.