### PR TITLE
fix(ci): migrate GitHub Actions workflows to Node 24

### DIFF
--- a/.github/workflows/semantic-pull-request.yaml
+++ b/.github/workflows/semantic-pull-request.yaml
@@ -15,6 +15,8 @@ jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     environment: dev
     steps:
       - uses: amannn/action-semantic-pull-request@v5

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   semantic-release:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     environment: dev
     steps:
       - name: Generate GitHub App token
@@ -32,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version: "24"
 
       - name: Install Dependencies
         run: npm clean-install

--- a/.github/workflows/test-template.yaml
+++ b/.github/workflows/test-template.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   test-template:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     environment: dev
     steps:
       - name: Checkout
@@ -26,7 +28,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: 'template/frontend/package*.json'
 

--- a/template/.github/workflows/main.yaml
+++ b/template/.github/workflows/main.yaml
@@ -5,6 +5,7 @@ on: [ push, pull_request ]
 env:
   AWS_REGION: ${{ '{{ vars.AWS_REGION }}' }}
   AWS_ACCOUNT_ID: ${{ '{{ vars.AWS_ACCOUNT_ID }}' }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   check-lint-and-formatting:
@@ -19,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Frontend Lint & Typecheck & Test
         run: make check-lint-and-test-frontend
 {% endif %}

--- a/template/.github/workflows/semantic-release.yaml
+++ b/template/.github/workflows/semantic-release.yaml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   semantic-release:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     environment: dev
     steps:
       - name: Checkout
@@ -24,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version: "24"
 
       - name: Install Dependencies
         run: npm install semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/github @semantic-release/commit-analyzer conventional-changelog-conventionalcommits


### PR DESCRIPTION
Summary
- Migrate GitHub Actions workflows to the Node 24 runner ahead of GitHub’s Node 20 deprecation ([getscaf/scaf#547](https://github.com/getscaf/scaf/issues/547))
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to all affected jobs in this repo and the generated template workflows
- Pin `actions/setup-node` to Node 24 (replacing `lts/*` and EOL Node 20 in the template `main` workflow)
Bump template `main.yaml` from `actions/setup-node@v3` to `@v4`