### PR TITLE
fix: oom during test template #551

### DIFF
--- a/template/Makefile
+++ b/template/Makefile
@@ -120,9 +120,9 @@ compile-frontend: frontend/package.json ## compile latest frontend dependencies 
 
 init-frontend-dependencies: ## compile initial frontend dependencies to be built into the docker image
 	@docker run --rm --user $(shell id -u):$(shell id -g) -w "/app" -v $(shell pwd)/frontend:/app -e npm_config_cache=/tmp/.npm node:lts /bin/bash -c \
-		"xargs npm install < dependencies-init.txt"
+		"xargs npm install --legacy-peer-deps < dependencies-init.txt"
 	@docker run --rm --user $(shell id -u):$(shell id -g) -w "/app" -v $(shell pwd)/frontend:/app -e npm_config_cache=/tmp/.npm node:lts /bin/bash -c \
-		"xargs npm install --save-dev < dependencies-dev-init.txt"
+		"xargs npm install --save-dev --legacy-peer-deps < dependencies-dev-init.txt"
 
 shell-backend:  ## Shell into the running Django container
 	$(KUBECTL_EXEC_BACKEND)

--- a/template/Makefile
+++ b/template/Makefile
@@ -120,9 +120,9 @@ compile-frontend: frontend/package.json ## compile latest frontend dependencies 
 
 init-frontend-dependencies: ## compile initial frontend dependencies to be built into the docker image
 	@docker run --rm --user $(shell id -u):$(shell id -g) -w "/app" -v $(shell pwd)/frontend:/app -e npm_config_cache=/tmp/.npm node:lts /bin/bash -c \
-		"xargs npm install --legacy-peer-deps < dependencies-init.txt"
+		"xargs -n 5 npm install < dependencies-init.txt"
 	@docker run --rm --user $(shell id -u):$(shell id -g) -w "/app" -v $(shell pwd)/frontend:/app -e npm_config_cache=/tmp/.npm node:lts /bin/bash -c \
-		"xargs npm install --save-dev --legacy-peer-deps < dependencies-dev-init.txt"
+		"xargs -n 5 npm install --save-dev < dependencies-dev-init.txt"
 
 shell-backend:  ## Shell into the running Django container
 	$(KUBECTL_EXEC_BACKEND)


### PR DESCRIPTION
npm was OOMing (~4GB heap) while resolving peer dependency conflicts introduced by recent package releases (eslint 9.39.4, graphql-codegen 7.1.3). The ERESOLVE algorithm's memory use balloons with this many conflicting packages. Using --legacy-peer-deps skips that resolution path, matching the approach already used in the compile-frontend target.

---

With --legacy-peer-deps, npm ignores peer dependency constraints entirely, so it installs eslint@10.5.0 (latest) and just warns. That's what caused the breakage.

Without --legacy-peer-deps, npm enforces peer deps. When eslint and eslint-config-next land in the same batch (they do — lines 12 and 13 → batch 3 with -n 5), npm resolves eslint to the latest version satisfying all constraints in that batch. The constraint from eslint-config-next (^7||^8||^9) is the binding one, so npm picks the latest eslint 9.x instead of 10.x.

The -n 5 batching is necessary to ensure they're resolved together in one npm install invocation — if eslint were in an earlier batch without eslint-config-next, npm would have no constraint to apply and would install 10.x first. Then when eslint-config-next arrived in a later batch, npm would either ERESOLVE or install a conflicting copy.
