### PR TITLE
feat: add celery init containers #179

### DIFF
--- a/template/k8s/base/celery.yaml
+++ b/template/k8s/base/celery.yaml
@@ -29,6 +29,30 @@ spec:
         app: celery
     spec:
       priorityClassName: app-medium-priority
+      initContainers:
+        - name: check-db-ready
+          image: postgres:17
+          command: [
+              "sh",
+              "-c",
+              "until pg_isready -h $(POSTGRES_HOST);
+              do echo waiting for postgres; sleep 2; done;",
+            ]
+        - name: wait-for-migrations
+          image: backend:latest
+          command:
+            - sh
+            - -c
+            - |
+              until python manage.py migrate --check; do
+                echo "waiting for migrations to be applied";
+                sleep 5;
+              done
+          envFrom:
+            - configMapRef:
+                name: app-config
+            - secretRef:
+                name: secrets-config
       containers:
         - name: celeryworker
           image: backend:latest

--- a/template/k8s/local/kustomization.yaml
+++ b/template/k8s/local/kustomization.yaml
@@ -32,3 +32,14 @@ patches:
   target:
     kind: Deployment
     name: backend
+{%- if copier__use_celery %}
+- patch: |-
+    - op: add
+      path: /spec/template/spec/initContainers/0/env
+      value:
+        - name: POSTGRES_HOST
+          value: postgres
+  target:
+    kind: Deployment
+    name: celery
+{%- endif %}

--- a/template/k8s/sandbox/kustomization.yaml
+++ b/template/k8s/sandbox/kustomization.yaml
@@ -59,6 +59,30 @@ patches:
 {%- if copier__use_celery %}
 - patch: |-
     - op: add
+      path: /spec/template/spec/initContainers/0/env
+      value:
+        - name: POSTGRES_HOST
+          valueFrom:
+            secretKeyRef:
+              name: postgres-app
+              key: host
+    - op: replace
+      path: /spec/template/spec/initContainers/0/command
+      value: ["sh", "-c", "until pg_isready -h $(POSTGRES_HOST); do echo waiting for postgres; sleep 2; done;"]
+    - op: add
+      path: /spec/template/spec/initContainers/1/env
+      value:
+        - name: POSTGRES_HOST
+          valueFrom:
+            secretKeyRef:
+              name: postgres-app
+              key: host
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: postgres-app
+              key: uri
+    - op: add
       path: /spec/template/spec/containers/0/env
       value:
         - name: POSTGRES_HOST


### PR DESCRIPTION
Fixes #179 

Prevent celery workers from starting until Postgres is reachable and Django migrations have been applied, avoiding startup crashes and stale-schema task execution.

- Base deployment gains readiness and migration-check init containers
- Local overlay wires the in-cluster Postgres host
- Sandbox overlay wires host and connection URI from the managed Postgres secret